### PR TITLE
move matplotlib imports inside functions

### DIFF
--- a/ephypype/aux_tools.py
+++ b/ephypype/aux_tools.py
@@ -1,7 +1,8 @@
-"""Aux functions.
+"""Aux functions"""
 
-AUTOR: dmalt
-"""
+# Authors: Dmitrii Altukhov <daltuhov@hse>
+#
+# License: BSD (3-clause)
 
 from contextlib import contextmanager
 import os

--- a/ephypype/commands/neuropycon.py
+++ b/ephypype/commands/neuropycon.py
@@ -15,7 +15,7 @@ import os
 @click.option('--plugin', '-p',
               type=click.Choice(['Linear', 'MultiProc', 'PBS']),
               help='plugin to use; use Linear for single-thread\
- computation, MultiProc parallel computation on local\
+ computation, MultiProc for parallel computation on local\
  machine and PBS to compute on cluster',
               default='MultiProc')
 @click.option('--save-path', '-s', type=click.Path(), default=os.getcwd(),

--- a/ephypype/commands/tests/test_cli.py
+++ b/ephypype/commands/tests/test_cli.py
@@ -4,13 +4,14 @@
 #
 # License: BSD (3-clause)
 
-import matplotlib # noqa
-matplotlib.use('Agg')  # noqa; for testing don't use X server
 
 import os
 import os.path as op
 from ephypype.commands import neuropycon
 from click.testing import CliRunner
+
+import matplotlib
+matplotlib.use('Agg')  # for testing don't use X server
 
 
 def test_input_linear():

--- a/ephypype/gather/gather_conmats.py
+++ b/ephypype/gather/gather_conmats.py
@@ -6,7 +6,6 @@ import itertools as iter
 from itertools import combinations
 
 from mne.viz import circular_layout, plot_connectivity_circle
-import matplotlib.pyplot as plt
 
 
 def atoi(text):
@@ -68,6 +67,7 @@ def plot_tab_circular_connectivity(list_list_conmat, all_elec_labels,
                                    color_bar='gist_rainbow', column_labels=[],
                                    row_labels=[]):
     """Plot tab circular conectivity."""
+    import matplotlib.pyplot as plt
     nb_lines = len(list_list_conmat)
     print(nb_lines)
 

--- a/ephypype/pipelines/preproc_meeg.py
+++ b/ephypype/pipelines/preproc_meeg.py
@@ -3,8 +3,6 @@
 Authors: Dmitrii Altukhov <dm-altukhov@ya.ru>
          Annalisa Pascarella <a.pascarella@iac.cnr.it>
 """
-import matplotlib
-matplotlib.use('PS')
 
 
 def get_ext_file(raw_file):

--- a/ephypype/tests/test_power.py
+++ b/ephypype/tests/test_power.py
@@ -1,10 +1,10 @@
 """Test power."""
+import mne
+
+from ephypype.power import compute_and_save_psd
+
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
-
-import mne  # noqa
-
-from ephypype.power import compute_and_save_psd  # noqa
 
 data_path = mne.datasets.sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'

--- a/ephypype/tests/test_preproc.py
+++ b/ephypype/tests/test_preproc.py
@@ -1,10 +1,11 @@
 """Test power."""
+
+import mne
+
+from ephypype.preproc import preprocess_fif, compute_ica
+
 import matplotlib
 matplotlib.use('Agg')  # for testing don't use X server
-
-import mne  # noqa
-
-from ephypype.preproc import preprocess_fif, compute_ica  # noqa
 
 data_path = mne.datasets.sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'


### PR DESCRIPTION
Fix bad matplotlib imports across the project. 
- Move matplotlib imports inside functions to avoid backend problems when launching tests in headless mode.
- Move `matplotlib.use('Agg')` in tests after all ephypype imports so Travis could detect  at the PR stage if someone adds global matplotlib imports to ephypype.
- Closes #34 
- Closes #43