### PR TITLE
Fix epochs node

### DIFF
--- a/ephypype/preproc.py
+++ b/ephypype/preproc.py
@@ -8,7 +8,7 @@ import os
 import sys
 import numpy as np
 
-from mne import pick_types, Epochs
+from mne import pick_types, read_epochs, Epochs
 from mne.io import read_raw_fif
 from mne.preprocessing import ICA, read_ica
 from mne.preprocessing import create_ecg_epochs, create_eog_epochs

--- a/ephypype/preproc.py
+++ b/ephypype/preproc.py
@@ -8,7 +8,7 @@ import os
 import sys
 import numpy as np
 
-from mne import pick_types, read_epochs
+from mne import pick_types, Epochs
 from mne.io import read_raw_fif
 from mne.preprocessing import ICA, read_ica
 from mne.preprocessing import create_ecg_epochs, create_eog_epochs
@@ -407,9 +407,9 @@ def _create_epochs(fif_file, ep_length):
     else:
         raise Exception('File {} is too short!'.format(fif_file))
 
-    epochs = read_epochs(raw, events=events, tmin=0, tmax=ep_length,
-                         preload=True, picks=picks, proj=False,
-                         flat=flat, reject=reject)
+    epochs = Epochs(raw, events=events, tmin=0, tmax=ep_length,
+                    preload=True, picks=picks, proj=False,
+                    flat=flat, reject=reject)
 
     _, base, ext = split_f(fif_file)
     savename = os.path.abspath(base + '-epo' + ext)

--- a/ephypype/tests/test_preproc.py
+++ b/ephypype/tests/test_preproc.py
@@ -1,6 +1,8 @@
 """Test power."""
 
 import mne
+import nipype.pipeline.engine as pe
+from ephypype.interfaces.mne.preproc import CreateEp
 from ephypype.preproc import _preprocess_fif, _compute_ica
 from ephypype.aux_tools import _change_wd
 
@@ -11,6 +13,16 @@ matplotlib.use('Agg')  # for testing don't use X server
 data_path = mne.datasets.sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_raw.fif'
 filter_raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
+
+
+def test_epoching_node():
+    """Test epoching node"""
+    _change_wd()
+    epoch_node = pe.Node(interface=CreateEp(), name='epoching')
+    epoch_node.inputs.ep_length = 1  # split in 1 second epochs
+
+    epoch_node.inputs.fif_file = raw_fname
+    epoch_node.run()
 
 
 def test_preprocess_fif():

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings=
-    ignore::DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings=
+    ignore::DeprecationWarning


### PR DESCRIPTION
Closes #63;
Suppresses deprecation warnings in pytest which were cluttering output with thousands of messages like this:
`DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead  out = np.fromstring(fid.read(read_size), dtype=dtype)`
coming from mne/io/tag.py